### PR TITLE
fix: remove loading race conditions

### DIFF
--- a/socrates.html
+++ b/socrates.html
@@ -139,20 +139,19 @@ var Module = {
     preRun: [() => bindStdin(Module)]
 };
 
-SWIPL(Module).then((module) => {
+async function fetchWrite(link, file) {
+    const response = await fetch(link);
+    await Module.FS.writeFile(file, await response.text());
+}
+
+SWIPL(Module).then(async (module) => {
+    await fetchWrite('https://josd.github.io/eye/eye.pl', '/eye.pl');
+    await fetchWrite('https://josd.github.io/eye/reasoning/socrates/socrates.n3', 'socrates.n3');
+    await fetchWrite('https://josd.github.io/eye/reasoning/socrates/socrates-query.n3', 'socrates-query.n3');
+
     pl("format('SWI-Prolog WebAssembly ready!~n')");
     pl("set_prolog_flag(tty_control, true)");
 });
-
-fetch('https://josd.github.io/eye/eye.pl')
-    .then(response => response.text())
-    .then(data => (Module.FS.writeFile('/eye.pl', data)));
-fetch('https://josd.github.io/eye/reasoning/socrates/socrates.n3')
-    .then(response => response.text())
-    .then(data => (Module.FS.writeFile('socrates.n3', data)));
-fetch('https://josd.github.io/eye/reasoning/socrates/socrates-query.n3')
-    .then(response => response.text())
-    .then(data => (Module.FS.writeFile('socrates-query.n3', data)));
 </script>
 </body>
 </html>


### PR DESCRIPTION
Uses async/await to avoid race conditions. Making the fetches in-order doesn't noticably slow down anything so no point trying to make just those parts async for now.